### PR TITLE
Feature/insta clone08 ユーザーの詳細ページに投稿一覧を表示する

### DIFF
--- a/app/views/posts/_thumbnail_post.html.slim
+++ b/app/views/posts/_thumbnail_post.html.slim
@@ -1,0 +1,9 @@
+/ ☆そのuserの投稿の画像をタイル表示
+/ 変数名(thumbnail_post)はパーシャル名と同じにしないといけない
+/ class: 'thumbs' = application.scss内に記述
+/ post_path(URLヘルパーメソッド) = /posts/:id
+/ iconと同じようにimage_tagでリンクに画像を設定
+/ thumbnail_post.images.first.url = CarrierWaveがpublic/uploads/post/imagesフォルダから一枚目の画像を持ってくる
+.col-md-4.mb-3
+  = link_to post_path(thumbnail_post), class: 'thumbs' do
+    = image_tag thumbnail_post.images.first.url

--- a/app/views/posts/_thumbnail_post.html.slim
+++ b/app/views/posts/_thumbnail_post.html.slim
@@ -4,6 +4,7 @@
 / post_path(URLヘルパーメソッド) = /posts/:id
 / iconと同じようにimage_tagでリンクに画像を設定
 / thumbnail_post.images.first.url = CarrierWaveがpublic/uploads/post/imagesフォルダから一枚目の画像を持ってくる
+/ .col-md-4.mb-3の下の行にコメントを入れると画像が表示されなくなるのは何故なのでしょうか？
 .col-md-4.mb-3
   = link_to post_path(thumbnail_post), class: 'thumbs' do
     = image_tag thumbnail_post.images.first.url

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -9,7 +9,7 @@ nav.navbar.navbar-expand-lg.navbar-light.bg-white
         = link_to new_post_path, class: 'nav-link' do
           = icon 'far', 'image', class: 'fa-lg'
       li.nav-item
-        a.nav-link href="#"
+        = link_to user_path(current_user), class: 'nav-link' do
           = icon 'far', 'heart', class: 'fa-lg'
       li.nav-item
         a.nav-link href="#"

--- a/app/views/users/_thumbnail_post.html.slim
+++ b/app/views/users/_thumbnail_post.html.slim
@@ -1,0 +1,3 @@
+.col-md-4.mb-3
+= link_to post_path(thumbnail_post), class: 'thumbs' do
+   = image_tag thumbnail_post.images.first.url

--- a/app/views/users/_thumbnail_post.html.slim
+++ b/app/views/users/_thumbnail_post.html.slim
@@ -1,3 +1,0 @@
-.col-md-4.mb-3
-= link_to post_path(thumbnail_post), class: 'thumbs' do
-   = image_tag thumbnail_post.images.first.url

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,7 +1,7 @@
 / ユーザー詳細ページ
 .container
   .row
-    .col-md-6.offset-md-3
+    .col-md-10.offset-md-1
       .card
         .card-body
           .text-center.mb-3
@@ -10,3 +10,6 @@
             = @user.username
           .text-center
             = render 'follow_area', user: @user
+          hr
+          .row
+            = render partial: 'posts/thumbnail_post', collection: @user.posts

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -12,4 +12,6 @@
             = render 'follow_area', user: @user
           hr
           .row
+            / partial = viewの一部を別ファイルに切り出し、可読性と再利用性を上げる。
+            / Viewでの繰り返し部分を、eachメソッドを使用するのではなく、コレクションをレンダリングすることで実装する。
             = render partial: 'posts/thumbnail_post', collection: @user.posts


### PR DESCRIPTION
**内容**
ユーザーの詳細ページに同ユーザーの投稿を一覧表示させてください。

**補足**
- タイル表示させる
- ヘッダーのユーザーアイコンに自分のユーザー詳細ページへのリンクを設定してさせる

**苦労したこと**
サムネイルを表示しているimage_tagの行を理解すること